### PR TITLE
Removes _from

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,11 +77,10 @@ module.exports = class DSA {
       this.ABI.core.list,
       this.address.core.list
     );
-    var _from = this.address.genesis;
-    return new Promise(async function (resolve, reject) {
+    return new Promise(async (resolve, reject) => {
       return await _c.methods
         .accounts()
-        .call({ from: _from })
+        .call({ from: this.address.genesis })
         .then((count) => {
           resolve(count);
         })
@@ -101,11 +100,10 @@ module.exports = class DSA {
       this.ABI.resolvers.core,
       this.address.resolvers.core
     );
-    var _from = this.address.genesis;
-    return new Promise(async function (resolve, reject) {
+    return new Promise(async (resolve, reject) => {
       return await _c.methods
         .getAuthorityDetails(_authority)
-        .call({ from: _from })
+        .call({ from: this.address.genesis })
         .then((_d) => {
           var _l = _d.IDs.length;
           var accounts = [];
@@ -133,11 +131,10 @@ module.exports = class DSA {
       this.ABI.resolvers.core,
       this.address.resolvers.core
     );
-    var _from = this.address.genesis;
-    return new Promise(async function (resolve, reject) {
+    return new Promise(async (resolve, reject) => {
       return await _c.methods
         .getIDAuthorities(_id)
-        .call({ from: _from })
+        .call({ from: this.address.genesis })
         .then((data) => {
           resolve(data);
         })
@@ -156,11 +153,10 @@ module.exports = class DSA {
       this.ABI.resolvers.core,
       this.address.resolvers.core
     );
-    var _from = this.address.genesis;
-    return new Promise(async function (resolve, reject) {
+    return new Promise(async  (resolve, reject) => {
       return await _c.methods
         .getAccountAuthorities(_addr)
-        .call({ from: _from })
+        .call({ from: this.address.genesis })
         .then((data) => {
           resolve(data);
         })


### PR DESCRIPTION
Note that we do not need to use the `_from = this.address.genesis` if we use the double arrow notation to define the promise. 

This is because using the double arrow will allow "this" to refer to the parent context.

Instead of  `new Promise(async function (resolve, reject) `, use  `new Promise(async (resolve, reject) => `, and "this" will work.

Refer to changes in this PR for reference.

Cc @thrilok209 @Sowmayjain  @KaymasJain 