### PR TITLE
Token list refactor

### DIFF
--- a/internal.md
+++ b/internal.md
@@ -41,7 +41,7 @@ const DSA = require('dsa-sdk');
 const web3 = new Web3(new Web3.providers.HttpProvider(ETH_NODE_URL))
 ```
 
-Now instantiate DSA.
+Now instantiate DSA. It is important to note that if you are instantiating this before your web3 is connected, you need to re-instantiate after your web3 is connected.
  
 ```js
 const dsa = new DSA(web3);
@@ -122,6 +122,27 @@ dsa.build()
 ### Returns
 `String`: Transaction hash `0x.....`.
 
+## .getTokenBalancesByAddress()
+
+Get the balances for the base tokens 
+
+```js
+dsa.getTokenBalancesByAddress(address)
+  .then(data => {
+    return data
+  })
+  .catch(error => {
+    return error
+  })
+```
+
+### Parameters
+`address` - An ethereum address.
+
+### Returns
+`List` of tokens, where the key is the symbol and the value is the formatted balance {eth: 2, dai: 50.1}
+
+
 ## .getAuthByAddress()
 
 Get all the authorised address(es) of a DSA by address.
@@ -176,13 +197,13 @@ Add the series of transactions details in the instance.
 spells.add({
  connector: "basic", // name
  method: "deposit", // method
- args: [dsa.token.usdc.address, 1000000, 0, 1] // method arguments
+ args: [dsa.tokens.info.usdc.address, 1000000, 0, 1] // method arguments
 });
 
 spells.add({
  connector: "basic",
  method: "withdraw",
- args: [dsa.token.usdc.address, 0, "0x03d70891b8994feB6ccA7022B25c32be92ee3725", 1, 0]
+ args: [dsa.tokens.info.usdc.address, 0, "0x03d70891b8994feB6ccA7022B25c32be92ee3725", 1, 0]
 });
 ```
 
@@ -225,6 +246,11 @@ Following are a few internal functions.
 * dsa.internal.getConnectorInterface(connector, method)
 * dsa.internal.encodeMethod(Object)
 * dsa.internal.encodeSpells(Object)
+
+## Constants
+* dsa.tokens.info (full map of token info)
+* dsa.tokens.getList({type})
+* dsa.tokens.getDataList({type, field})
 
 <!-- ## .estimateCastGas()
 

--- a/src/constant/tokens.js
+++ b/src/constant/tokens.js
@@ -1,4 +1,31 @@
 /**
+ * Returns a list of token objects filtered by the type
+ */
+exports.getList = ({type=null}) => {
+  return Object.keys(this.info)
+    .reduce((list, key) => {
+        if (this.info[key].type != type) { return list }
+        list.push(this.info[key])
+        return list
+    }, [])
+}
+
+/**
+ * Returns a list filtered by the token type and the field needed
+ * example: getData({type:"ctoken",field:"address"}) will return all the ctoken addresses in a list
+ */
+exports.getDataList = ({type=null, field=null}) => {
+  return Object.values(this.info)
+  .filter((a) =>  { 
+      return type ? a.type == type : true
+  })
+  .map((a) => {
+      return field ? a[field] : a
+  })
+}
+
+
+/**
  * @param type
  * @param symbol
  * @param name
@@ -6,154 +33,4 @@
  * @param decimal
  * @param factor (optional) collatreal factor, used in ctokens
  */
-module.exports = {
-  eth: {
-    type: "token",
-    symbol: "ETH",
-    name: "Ethereum",
-    address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-    decimals: 18,
-  },
-  dai: {
-    type: "token",
-    symbol: "DAI",
-    name: "DAI Stable",
-    address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-    decimals: 18,
-  },
-  usdc: {
-    type: "token",
-    symbol: "USDC",
-    name: "USD Coin",
-    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    decimals: 6,
-  },
-  sai: {
-    type: "token",
-    symbol: "SAI",
-    name: "SAI Stable",
-    address: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
-    decimals: 18,
-  },
-  mkr: {
-    type: "token",
-    symbol: "MKR",
-    name: "MakerDAO",
-    address: "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
-    decimals: 18,
-  },
-  zrx: {
-    type: "token",
-    symbol: "ZRX",
-    name: "0x Protocol",
-    address: "0xe41d2489571d322189246dafa5ebde1f4699f498",
-    decimals: 18,
-  },
-  rep: {
-    type: "token",
-    symbol: "REP",
-    name: "Augur",
-    address: "0x1985365e9f78359a9b6ad760e32412f4a445e862",
-    decimals: 18,
-  },
-  tusd: {
-    type: "token",
-    symbol: "TUSD",
-    name: "TrueUSD",
-    address: "0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E",
-    decimals: 18,
-  },
-  bat: {
-    type: "token",
-    symbol: "BAT",
-    name: "Basic Att.",
-    address: "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
-    decimals: 18,
-  },
-  knc: {
-    type: "token",
-    symbol: "KNC",
-    name: "Kyber Network",
-    address: "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
-    decimals: 18,
-  },
-  wbtc: {
-    type: "token",
-    symbol: "WBTC",
-    name: "Wrapped BTC",
-    address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-    decimals: 8,
-  },
-  ceth: {
-    type: "ctoken",
-    symbol: "CETH",
-    name: "Compound ETH",
-    address: "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
-    decimals: 8,
-    factor: 0.75,
-    root: "eth",
-  },
-  cdai: {
-    type: "ctoken",
-    symbol: "CDAI",
-    name: "Compound DAI",
-    address: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
-    decimals: 8,
-    factor: 0.75,
-    root: "dai",
-  },
-  cusdc: {
-    type: "ctoken",
-    symbol: "CUSDC",
-    name: "Compound USDC",
-    address: "0x39aa39c021dfbae8fac545936693ac917d5e7563",
-    decimals: 8,
-    factor: 0.75,
-    root: "usdc",
-  },
-  csai: {
-    type: "ctoken",
-    symbol: "CSAI",
-    name: "Compound SAI",
-    address: "0xf5dce57282a584d2746faf1593d3121fcac444dc",
-    decimals: 8,
-    factor: 0,
-    root: "sai",
-  },
-  czrx: {
-    type: "ctoken",
-    symbol: "CZRX",
-    name: "Compound ZRX",
-    address: "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
-    decimals: 8,
-    factor: 0.6,
-    root: "zrx",
-  },
-  crep: {
-    type: "ctoken",
-    symbol: "CREP",
-    name: "Compound REP",
-    address: "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
-    decimals: 8,
-    factor: 0.4,
-    root: "rep",
-  },
-  cbat: {
-    type: "ctoken",
-    symbol: "CBAT",
-    name: "Compound BAT",
-    address: "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
-    decimals: 8,
-    factor: 0.6,
-    root: "bat",
-  },
-  cwbtc: {
-    type: "ctoken",
-    symbol: "CWBTC",
-    name: "Compound WBTC",
-    address: "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
-    decimals: 8,
-    factor: 0,
-    root: "wbtc",
-  },
-};
+exports.info = require("./tokensInfo.json") 

--- a/src/constant/tokens.js
+++ b/src/constant/tokens.js
@@ -31,6 +31,6 @@ exports.getDataList = ({type=null, field=null}) => {
  * @param name
  * @param address
  * @param decimal
- * @param factor (optional) collatreal factor, used in ctokens
+ * @param factor (optional) collateral factor, used in ctokens
  */
 exports.info = require("./tokensInfo.json") 

--- a/src/constant/tokensInfo.json
+++ b/src/constant/tokensInfo.json
@@ -1,0 +1,153 @@
+{
+    "eth": {
+      "type": "token",
+      "symbol": "eth",
+      "name": "Ethereum",
+      "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "decimals": 18
+    },
+    "dai": {
+      "type": "token",
+      "symbol": "dai",
+      "name": "DAI Stable",
+      "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      "decimals": 18
+    },
+    "usdc": {
+      "type": "token",
+      "symbol": "usdc",
+      "name": "USD Coin",
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "decimals": 6
+    },
+    "sai": {
+      "type": "token",
+      "symbol": "sai",
+      "name": "SAI Stable",
+      "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      "decimals": 18
+    },
+    "mkr": {
+      "type": "token",
+      "symbol": "mkr",
+      "name": "MakerDAO",
+      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "decimals": 18
+    },
+    "zrx": {
+      "type": "token",
+      "symbol": "zrx",
+      "name": "0x Protocol",
+      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+      "decimals": 18
+    },
+    "rep": {
+      "type": "token",
+      "symbol": "rep",
+      "name": "Augur",
+      "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
+      "decimals": 18
+    },
+    "tusd": {
+      "type": "token",
+      "symbol": "tusd",
+      "name": "TrueUSD",
+      "address": "0x8dd5fbCe2F6a956C3022bA3663759011Dd51e73E",
+      "decimals": 18
+    },
+    "bat": {
+      "type": "token",
+      "symbol": "bat",
+      "name": "Basic Att.",
+      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "decimals": 18
+    },
+    "knc": {
+      "type": "token",
+      "symbol": "knc",
+      "name": "Kyber Network",
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "decimals": 18
+    },
+    "wbtc": {
+      "type": "token",
+      "symbol": "wbtc",
+      "name": "Wrapped BTC",
+      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "decimals": 8
+    },
+    "ceth": {
+      "type": "ctoken",
+      "symbol": "ceth",
+      "name": "Compound ETH",
+      "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
+      "decimals": 8,
+      "factor": 0.75,
+      "root": "eth"
+    },
+    "cdai": {
+      "type": "ctoken",
+      "symbol": "cdai",
+      "name": "Compound DAI",
+      "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+      "decimals": 8,
+      "factor": 0.75,
+      "root": "dai"
+    },
+    "cusdc": {
+      "type": "ctoken",
+      "symbol": "cusdc",
+      "name": "Compound USDC",
+      "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+      "decimals": 8,
+      "factor": 0.75,
+      "root": "usdc"
+    },
+    "csai": {
+      "type": "ctoken",
+      "symbol": "csai",
+      "name": "Compound SAI",
+      "address": "0xf5dce57282a584d2746faf1593d3121fcac444dc",
+      "decimals": 8,
+      "factor": 0,
+      "root": "sai"
+    },
+    "czrx": {
+      "type": "ctoken",
+      "symbol": "czrx",
+      "name": "Compound ZRX",
+      "address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
+      "decimals": 8,
+      "factor": 0.6,
+      "root": "zrx"
+    },
+    "crep": {
+      "type": "ctoken",
+      "symbol": "CREP",
+      "name": "Compound REP",
+      "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+      "decimals": 8,
+      "factor": 0.4,
+      "root": "rep"
+    },
+    "cbat": {
+      "type": "ctoken",
+      "symbol": "CBAT",
+      "name": "Compound BAT",
+      "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
+      "decimals": 8,
+      "factor": 0.6,
+      "root": "bat"
+    },
+    "cwbtc": {
+      "type": "ctoken",
+      "symbol": "CWBTC",
+      "name": "Compound WBTC",
+      "address": "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4",
+      "decimals": 8,
+      "factor": 0,
+      "root": "wbtc"
+    }
+}
+  
+  

--- a/src/index.js
+++ b/src/index.js
@@ -132,10 +132,9 @@ module.exports = class DSA {
       this.address.resolvers.balances
     );
 
-    var tokenSymbols = Object.keys(token);
-    var tokenAddresses = tokenSymbols.map((sym) => {
-      return token[sym].address;
-    });
+    const tokensInfo = tokens.getList({type:"token"})
+    const tokenAddresses = tokens.getDataList({type:"token",field:"address"})
+
     return new Promise((resolve, reject) => {
       return _c.methods
         .getBalances(_addr, tokenAddresses)
@@ -145,9 +144,8 @@ module.exports = class DSA {
             if (rawBalance == 0) {
               return map;
             }
-            var sym = tokenSymbols[index];
-            var info = token[sym];
-            map[sym] = rawBalance / 10 ** info["decimals"];
+            var sym = tokensInfo[index].symbol;
+            map[sym] = rawBalance / 10 ** tokensInfo[index].decimals
             return map;
           }, {});
           resolve(_b);

--- a/src/protocol/compound.js
+++ b/src/protocol/compound.js
@@ -6,6 +6,7 @@ module.exports = class Compound {
     this.ABI = _dsa.ABI;
     this.address = _dsa.address;
     this.tokens = _dsa.tokens;
+    this.web3 = _dsa.web3
   }
 
   /**
@@ -14,8 +15,7 @@ module.exports = class Compound {
    */
   ctokenMap(cTokenSymbol) {
     cTokenSymbol = cTokenSymbol.toLowerCase();
-    var tokens = this.tokens;
-    for (const key in tokens) {
+    for (const key in this.tokens.getList()) {
       if (key == cTokenSymbol) {
         return tokens[key].root;
       }
@@ -28,12 +28,11 @@ module.exports = class Compound {
    * @param {string} cTokens the cToken address
    */
   getPosition(address, cTokens) {
-    let that = this.data;
-    var _c = new that.web3.eth.Contract(
-      that.ABI.read["compound"],
-      that.address.read["compound"]
+    var _c = new this.web3.eth.Contract(
+      this.ABI.read["compound"],
+      this.address.read["compound"]
     );
-    return new Promise(async function (resolve, reject) {
+    return new Promise( async (resolve, reject) => {
       let compoundRawData = await _c.methods
         .getPosition(address, cTokens)
         .call()
@@ -51,7 +50,7 @@ module.exports = class Compound {
 
       let addrDecimal = {};
       let addrSymb = {};
-      Object.values(that.tokens).forEach((token) => {
+      Object.values(this.tokens.info).forEach((token) => {
         if (token.compound) {
           let _token = this.ctokenMap[token.symbol.toLowerCase()];
           addrDecimal[token.address] = that.token[_token].decimals;


### PR DESCRIPTION
0/ no change to token format, but changed all symbols to lowercaps

1/ tokens data is now in tokensList.json

2/ raw token data can be accessed as tokens.info (more clear)
```
tokens.info
```

3/ helper functions in tokens returning array of either objects or the required fields

```  
// gets array of cTokens
const cTokens = tokens.getList({type:"ctoken"})

// get array of base token address
const tokenAddresses = tokens.getDataList({type:"token",field:"address"})
```

4/ also, added web3 from original dsa object into object in compound. there should not be a need to refer to parent dsa object. there was an error when i ran the getPositions function.

** Note the argument type is {type:xx, address:xx} are objects:
https://simonsmith.io/destructuring-objects-as-function-parameters-in-es6