### PR TITLE
Building a more generic token transfer mechanism

### DIFF
--- a/src/erc20.js
+++ b/src/erc20.js
@@ -27,7 +27,11 @@ module.exports = class Token {
     let _addr = await this.internal.getAddress();
     let web3 = this.web3;
     if (!_d.token) throw new Error("'token' is not defined.");
-    if (!_d.to) _d.to = this.dsa.instance.address;
+    if (!_d.to) {
+      let _dsa = !this.dsa ? this : this.dsa
+      _d.to = _dsa.instance.address;
+      if(_d.to == _dsa.address.genesis) throw new Error("'to' is not defined and instance is not set.");
+    }
     if (!_d.amount) throw new Error("'amount' is not defined");
     if (!_d.from) _d.from = _addr;
     if (
@@ -55,7 +59,7 @@ module.exports = class Token {
       );
       return new Promise((resolve, reject) => {
         return _c.methods
-          .transfer(_d.to, _d.amount)
+          .transfer(_d.to, this.helpers.bigNumInString(_d.amount)) 
           .send(_d)
           .on("transactionHash", (txHash) => {
             resolve(txHash);

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,9 @@ module.exports = class DSA {
     this.compound = new Compound(this);
     this.maker = new Maker(this);
     this.instapool = new InstaPool(this);
+
+    // defining methods where we need web3 access
+    this.tokens.transfer = this.erc20.transfer;
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ module.exports = class DSA {
     this.instapool = new InstaPool(this);
 
     // defining methods where we need web3 access
-    this.tokens.transfer = this.erc20.transfer;
+    this.transfer = this.erc20.transfer;
   }
 
   /**


### PR DESCRIPTION
#### Rationale behind the pull request

Right now the SDK allows transferring tokens via `dsa.erc20.transfer(Object)` without handling the ABIs and addresses but we should have a more generic function to transfer not only ERC20 tokens but also ETH (estimated to be the most transferable asset). That's why I think, its a good idea to transfer the tokens by a more generic function like `dsa.transfer(Object)`.

Let me know if you've any suggestion on the structure. If all good, could you test it out if it's working as expected? Accordingly, we will document it in the main readme file.

@thrilok209 @kaymasjain @mingyeow 