### PR TITLE
txHash backward compatibility

### DIFF
--- a/src/gnosis-safe/index.js
+++ b/src/gnosis-safe/index.js
@@ -277,9 +277,7 @@ module.exports = class GnosisSafe {
               await Promise.all([
                 this.apiHelpers.saveTxToHistory({ ...txArgs, hash, origin }),
               ]);
-              resolve({
-                txHash: hash,
-              });
+              resolve(hash);
             } catch (e) {}
           })
           .on("error", (error) => {


### PR DESCRIPTION
Fixed an error when initiating txn through gnosis safe (where just one signer is required). The dsa-sdk returns an `Object` whereas it should just return raw txn hash.

![telegram-cloud-photo-size-5-6206264632650345002-y](https://user-images.githubusercontent.com/24977803/91034004-a136a180-e647-11ea-84d9-d55b098f6a2a.jpg)
